### PR TITLE
Remove obsolete malloc.h include - fixes #2

### DIFF
--- a/convertvec.c
+++ b/convertvec.c
@@ -4,7 +4,6 @@
 #include <stdio.h>
 #include <string.h>
 #include <math.h>
-#include <malloc.h>
 #include <stdlib.h>
 
 const long long max_w = 2000;


### PR DESCRIPTION
The code doesn't compile as is on OS X and I think the header is unnecessary because the code doesn't do any malloc/free etc (and if it did stdlib.h should be enough).